### PR TITLE
Add insertOne Promise wrapper

### DIFF
--- a/src/data/games.js
+++ b/src/data/games.js
@@ -2,15 +2,17 @@ const data = require('../utils/data');
 const log = require('../utils/log');
 const { DUNGEONS_COLLECTION } = require('../constants/collections');
 
-const createGame = (name, createdBy) => {
-  return new Promise((resolve, reject) => {
-    data.db && data.db.collection(DUNGEONS_COLLECTION)
-      .insertOne({ name, createdBy, members: [createdBy] }, (err, { ops }) => {
-        const newGame = ops[0];
-        log.success(`Created new game ${newGame.name} (${newGame._id})`);
-        err ? reject(err) : resolve(newGame);
-      });
-  });
+const createGame = async (name, createdBy) => {
+  const newGame = await data
+    .insertOne(DUNGEONS_COLLECTION, {
+      name,
+      createdBy,
+      members: [createdBy]
+    })
+    .then(inserted => inserted);
+
+  log.success(`Created new game ${newGame.name} (${newGame._id})`);
+  return newGame;
 };
 
 module.exports = {

--- a/src/data/games.js
+++ b/src/data/games.js
@@ -3,15 +3,15 @@ const log = require('../utils/log');
 const { DUNGEONS_COLLECTION } = require('../constants/collections');
 
 const createGame = async (name, createdBy) => {
-  const newGame = await data
-    .insertOne(DUNGEONS_COLLECTION, {
+  const newGame = await data.insertOne(
+    DUNGEONS_COLLECTION, {
       name,
       createdBy,
       members: [createdBy]
-    })
-    .then(inserted => inserted);
+    });
 
   log.success(`Created new game ${newGame.name} (${newGame._id})`);
+
   return newGame;
 };
 

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -8,6 +8,8 @@ const dbName = process.env.DB_NAME;
 
 const mongoOptions = { useNewUrlParser: true, useUnifiedTopology: true };
 
+var db;
+
 const connectToMongoDB = async () => {
   mongo.connect(dbUri, mongoOptions, (err, client) => {
     if (err) {
@@ -16,7 +18,7 @@ const connectToMongoDB = async () => {
       return;
     }
 
-    exports.db = client.db(dbName);
+    db = client.db(dbName);
 
     log.cool(`Connected to DB: ${dbName}`);
     connect(true);
@@ -25,6 +27,21 @@ const connectToMongoDB = async () => {
 
 const connect = async (connected) => !connected && connectToMongoDB();
 
-exports.calculateTotalPages = (items, size) => items > size ? Math.ceil(items / size) : 1;
+const calculateTotalPages = (items, size) => items > size ? Math.ceil(items / size) : 1;
 
 connect();
+
+const insertOne = async (collection, document) => {
+  return new Promise((resolve, reject) => {
+    db.collection(collection)
+      .insertOne(document, (err, { ops }) => {
+        err ? reject(err) : resolve(ops[0]);
+      });
+  });
+}
+
+module.exports = {
+  db,
+  calculateTotalPages,
+  insertOne
+};


### PR DESCRIPTION
As discussed [here](https://github.com/andrew-brainerd/perkins-dungeon-master-server/pull/6#discussion_r390956942), added a simple wrapper to make the data layer call `async` to avoid weird Mongo callbacks.

Obviously we would want to add validation around the parameters, but I thought this was a good example to get us stated. All feedback welcome.