### PR TITLE
Basic inventory stuff

### DIFF
--- a/src/api/characters.js
+++ b/src/api/characters.js
@@ -14,7 +14,16 @@ characters.post('/', validator.body(postCharacterBody), async (req, res) => {
     location: 'startLocationGuid',
     playerId: createdBy,
     experiencePoints: 0,
-    remainingSpells: 3
+    remainingSpells: 3,
+    inventory: [ ],
+    abilityScores : {
+        strength : 9,
+        dexterity : 17,
+        constitution : 15,
+        intellect : 13,
+        wisdom : 13,
+        charisma : 17
+    }
   };
 
   const newCharacter = await charactersData.createCharacter(character);

--- a/src/constants/collections.js
+++ b/src/constants/collections.js
@@ -2,9 +2,11 @@
 const GAMES_COLLECTION = 'perkinsGames';
 const CHARACTERS_COLLECTION = 'perkinsCharacters';
 const PLAYERS_COLLECTION = 'perkinsPlayers';
+const ITEMS_COLLECTION = 'perkinsItems';
 
 module.exports = {
   GAMES_COLLECTION,
   CHARACTERS_COLLECTION,
-  PLAYERS_COLLECTION
+  PLAYERS_COLLECTION,
+  ITEMS_COLLECTION
 };

--- a/src/constants/magicNumbers.js
+++ b/src/constants/magicNumbers.js
@@ -1,0 +1,8 @@
+/**
+ * Base carry capacity is strength times 15.
+ */
+const CARRY_CAPACITY_SCALER = 15;
+
+module.exports = {
+    CARRY_CAPACITY_SCALER
+};

--- a/src/constants/units.js
+++ b/src/constants/units.js
@@ -1,0 +1,5 @@
+const WEIGHT = { singular: 'lb', plural: 'lbs' };
+
+module.exports = {
+    WEIGHT
+};

--- a/src/data/characters.js
+++ b/src/data/characters.js
@@ -2,6 +2,21 @@ const data = require('../utils/data');
 const log = require('../utils/log');
 const { CHARACTERS_COLLECTION } = require('../constants/collections');
 
+// This is only here until character creation is stable.
+// Once all characters in the system follow the required schema, it will no
+// longer be necessary.
+const supplementCharacter = character => {
+  if (!character) {
+    return undefined;
+  }
+
+  if (!character.inventory) {
+    character.inventory = [];
+  }
+
+  return character;
+}
+
 const createCharacter = async character => {
   const newCharacter = await data.insertOne(CHARACTERS_COLLECTION, character);
 
@@ -15,11 +30,21 @@ const getPlayerCharacters = async (page, size, playerId) => {
 };
 
 const getCharacter = async characterId => {
-  return await data.getById(CHARACTERS_COLLECTION, characterId);
+  return supplementCharacter(await data.getById(CHARACTERS_COLLECTION, characterId));
 };
+
+const getCharacterByName = async (name, gameId) => {
+  return supplementCharacter(await data.getByProperties(CHARACTERS_COLLECTION, { name, gameId }));
+}
+
+const updateCharacter = async character => {
+  return await data.saveObject(CHARACTERS_COLLECTION, character);
+}
 
 module.exports = {
   createCharacter,
   getPlayerCharacters,
-  getCharacter
+  getCharacter,
+  getCharacterByName,
+  updateCharacter
 };

--- a/src/data/items.js
+++ b/src/data/items.js
@@ -1,0 +1,15 @@
+const data = require('../utils/data');
+const { ITEMS_COLLECTION } = require('../constants/collections');
+
+const getItemByName = async name => {
+  return await data.getByProperty(ITEMS_COLLECTION, 'name', name);
+}
+
+const getItems = async itemIds => {
+  return await data.getAllByProperty(ITEMS_COLLECTION, '_id', { $in: itemIds });
+}
+
+module.exports = {
+  getItemByName,
+  getItems
+};

--- a/src/gameLogic/inventory.js
+++ b/src/gameLogic/inventory.js
@@ -1,0 +1,47 @@
+const { updateCharacter } = require('../data/characters');
+const { getItems } = require('../data/items');
+const { CARRY_CAPACITY_SCALER } = require('../constants/magicNumbers');
+const { keyBy } = require('lodash');
+
+/**
+ * Returns the given character's full inventory.
+ */
+const getInventory = async character => {
+  const items = keyBy(await getItems(character.inventory), '_id');
+
+  // Ensure output is 1:1 (duplicate items are actually duplicated)
+  return character.inventory.map(x => items[x]);
+};
+
+/**
+ * Returns a the current weight the character is carrying and theirmaximum carry capacity.
+ */
+const getCarryRatio = async character => {
+  const currentInventory = await getInventory(character);
+  // This number will need to include their current equipment
+  const currentWeight = currentInventory.reduce((total, item) => total + item.weight, 0);
+  return {current: currentWeight, max: character.abilityScores.strength * CARRY_CAPACITY_SCALER};
+};
+
+/**
+ * Attempts to add the given item to the character's inventory.
+ */
+const addItemToInventory = async (character, item) => {
+  const carryRatio = await getCarryRatio(character);
+
+  if (item.weight + carryRatio.current > carryRatio.max) {
+    return { added: false, carryRatio };
+  }
+
+  character.inventory.push(item._id);
+  await updateCharacter(character);
+
+  // Re-getting carry ratio in case other effects have been applied.
+  return { added: true, carryRatio: await getCarryRatio(character) };
+};
+
+module.exports = {
+  getInventory,
+  getCarryRatio,
+  addItemToInventory
+};

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -3,6 +3,7 @@
 const mongo = require('mongodb').MongoClient;
 const ObjectId = require('mongodb').ObjectId;
 const log = require('./log');
+const { omit } = require('lodash');
 
 const dbUri = process.env.MONGODB_URI;
 const dbName = process.env.DB_NAME;
@@ -83,6 +84,26 @@ const getByProperty = (collectionName, property, value) => {
   });
 };
 
+const getByProperties = (collectionName, query) => {
+  return new Promise((resolve, reject) => {
+    db.collection(collectionName)
+      .find(query)
+      .toArray((err, result) =>
+        err ? reject(err) : resolve(result[0])
+      );
+  });
+};
+
+const getAllByProperty = (collectionName, property, value) => {
+  return new Promise((resolve, reject) => {
+    db.collection(collectionName)
+      .find({ [property]: value })
+      .toArray((err, result) =>
+        err ? reject(err) : resolve(result)
+      );
+  });
+};
+
 const updateOne = async (collectionName, id, update) => {
   return new Promise((resolve, reject) => {
     try {
@@ -103,6 +124,22 @@ const updateOne = async (collectionName, id, update) => {
   })
 };
 
+const saveObject = async(collectionName, item) => {
+  return new Promise((resolve, reject) => {
+    try {
+      db.collection(collectionName)
+        .update(
+          { _id: item._id },
+          { $set: omit(item, '_id')},
+          { upsert: true },
+          err => err ? reject(err) : resolve()
+        );
+    } catch(err) {
+      reject(err);
+    }
+  });
+}
+
 module.exports = {
   db,
   calculateTotalPages,
@@ -110,5 +147,8 @@ module.exports = {
   getSome,
   getById,
   getByProperty,
-  updateOne
+  getByProperties,
+  getAllByProperty,
+  updateOne,
+  saveObject
 };

--- a/src/utils/grammar.js
+++ b/src/utils/grammar.js
@@ -1,0 +1,16 @@
+const articleForNoun = noun => {
+  if (!noun || noun === '') {
+    return 'an';
+  }
+
+  return ['a', 'e', 'i', 'o', 'u'].includes(noun.toLowerCase()[0]) ? 'an' : 'a';
+};
+
+const withUnits = (value, unit) => {
+    return `${value}${value === 1 ? unit.singular : unit.plural}`;
+};
+
+module.exports = {
+    articleForNoun,
+    withUnits
+};


### PR DESCRIPTION
![inventory-demo](https://user-images.githubusercontent.com/8814659/77834928-e26d6880-711e-11ea-8266-3f47174565ae.gif)

This adds some basic inventory logic, as well as some commands to show it off. I'm setting the precedent that `gm`-prefixed commands are for privileged players (like WoW GMs, to distinguish from the other meaning of `gm` in our context).  Eventually, we will want to either remove them or restrict them. For now, they serve to try stuff out since we don't actually have anything to tie incoming input to a specific character. Once we get that, we could do something like `show inventory` or `inventory` to show your own inventory.